### PR TITLE
new const_anon function

### DIFF
--- a/lib/Const/Fast.pm
+++ b/lib/Const/Fast.pm
@@ -61,7 +61,7 @@ sub const(\[$@%]@) {
 		croak 'Can\'t make variable readonly';
 	}
 	_make_readonly($_[0], 1);
-	return;
+	return $_[0];
 }
 
 1;    # End of Const::Fast
@@ -84,7 +84,8 @@ sub const(\[$@%]@) {
 
 =head2 const %var, %value...
 
-This the only function of this module and it is exported by default. It takes a scalar, array or hash lvalue as first argument, and a list of one or more values depending on the type of the first argument as the value for the variable. It will set the variable to that value and subsequently make it readonly. Arrays and hashes will be made deeply readonly.
+This the only function of this module and it is exported by default. It takes a scalar, array or hash lvalue as first argument, and a list of one or more values depending on the type of the first argument as the value for the variable. It will set the variable to that value and subsequently make it readonly. Arrays and hashes will be made deeply readonly. 
+The function also returns a reference to the (readonly, natch) value of the constant.
 
 Exporting is done using Sub::Exporter::Progressive. You may need to depend on Sub::Exporter explicitly if you need the latter's flexibility.
 

--- a/t/10-basics.t
+++ b/t/10-basics.t
@@ -101,4 +101,18 @@ subtest 'const return value' => sub {
 
 };
 
+subtest 'const_anon' => sub {
+    use Const::Fast 'const_anon';
+
+    is_deeply [ my $copy = const_anon [ 1..5 ] ], [ [ 1,2,3,4,5 ] ], 'array';
+    is_deeply [ const_anon { 1..4 } ], [ { 1,2,3,4 } ], 'hash';
+
+    throws_readonly { $copy->[0]= 'foo' };
+
+    throws_ok {
+        const_anon 'nope';
+    } qr/argument must be array or hash reference/, 'must be hash or array';
+
+};
+
 done_testing;

--- a/t/10-basics.t
+++ b/t/10-basics.t
@@ -91,4 +91,14 @@ throws_ok { &const(1, 1) } qr/^Invalid first argument, need an reference at/, 'F
 my $a = \{}; 
 lives_ok { const($a => $a) };
 
+subtest 'const return value' => sub {
+    is_deeply [ const my $foo => 'hello' ], [ \'hello' ], 'scalar';
+
+    is_deeply [ my $copy = const my @foo => 1..5 ], [ [ 1,2,3,4,5 ] ], 'array';
+    is_deeply [ const my %foo => 1..4 ], [ { 1,2,3,4 } ], 'hash';
+
+    throws_readonly { $copy->[0]= 'foo' }, 'still readonly';
+
+};
+
 done_testing;


### PR DESCRIPTION
Quicker way to return a readonly version of the ref. Typically, in my methods
I have

```
    const my %foo => ( a => 1 );
    return \%foo;
```

but now I can do

```
    return const_anon { a => 1 };
```
